### PR TITLE
Lhscans and Kissmanga Updates!

### DIFF
--- a/main.js
+++ b/main.js
@@ -13,8 +13,9 @@ let nwin;
 // It creates a main window from mainWin html.
 app.on('ready', function() {
     mainWin = new BrowserWindow({
-        width: 1200,
-        height: 800
+        width: 700,
+        height: 1080,
+        frame: false
     });
     //Load html for the view.
     mainWin.loadURL(url.format({

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "materialize-css": "^0.100.2",
     "mkdirp": "^0.5.1",
     "mkdirp-promise": "^5.0.1",
-    "npm": "^5.6.0",
     "request": "^2.83.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "materialize-css": "^0.100.2",
     "mkdirp": "^0.5.1",
     "mkdirp-promise": "^5.0.1",
+    "npm": "^5.6.0",
     "request": "^2.83.0"
   },
   "devDependencies": {

--- a/src/components/viewer.html
+++ b/src/components/viewer.html
@@ -4,11 +4,14 @@
     <title>Document</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/css/materialize.min.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <style>
+        .carousel { 
+            min-height: 1200px;
+        }
+    </style>
 </head>
 <body>
-    <h1>Viewer</h1>
-    <div id="chapView" class="carousel carousel-slider">
-        <a class="carousel-item" href="#one!"><img src="http://i.imgur.com/io0XxGa.jpg"></a>
+    <div id="chapView" class="carousel carousel-slider container">
     </div>
     <button id="abc" class="btn waves-effect waves-light" onclick="test(); return false;">Dew</button>
 

--- a/src/lib/mangasrc/kissmanga.js
+++ b/src/lib/mangasrc/kissmanga.js
@@ -70,7 +70,7 @@ function buttoKun() {
                         let file = fs.createWriteStream(path + "000" +
                             newLink.match(/\d+\w\d*.png|\d+\w\d*.jpe?g/));
 
-                        let req = http.get(newLink, function(response) {
+                        let downloader = http.get(newLink, function(response) {
                             response.pipe(file)
                         });
                     });

--- a/src/lib/mangasrc/kissmanga.js
+++ b/src/lib/mangasrc/kissmanga.js
@@ -55,8 +55,7 @@ function buttoKun() {
             hakuneko.kissmanga.getPages(chapter, function(error, pages) {
                 if (!error) {
                     chapter.p = pages; // Will be usefull later.
-                    console.log(pages);
-                    console.log(pages.length);
+
                     pages.forEach(function(item) {
                         item = item.trim();
                         item = item.match(/(.*\.jpe?g|.*\.png)/);

--- a/src/lib/mangasrc/kissmanga.js
+++ b/src/lib/mangasrc/kissmanga.js
@@ -1,6 +1,4 @@
-const hakuneko = require('hakuneko'),
-    https = require('https');
-
+const hakuneko = require('hakuneko');
 
 function buttoKun() {
     // Getting form informations.
@@ -17,29 +15,51 @@ function buttoKun() {
 
             chapter = hakuneko.base.createChapter('[VOL]', '[NR]', 'Title',
                 'lang', 'scanlator', `/Manga/${nmanga}`, []);
-            chapterNo = (chapters.length - chno) - 1; // Because of array
+
+            // Returns to the given chapter no.
+            let chapterNo = chapters.filter(function(obj) {
+                // Kissmanga puts double 0 in front of the all 1 digit chapters.
+                // But puts one 0 in front of 2 digit chapters.
+                let chapterNoFromTitle = obj.t.match(/\d+(\.\d+)?/);
+                if (chno > 0 && chno < 10) {
+                    return chapterNoFromTitle[0] == '0' + '0' + chno;
+                } else if (chno >= 10 && chno < 100) {
+                    return chapterNoFromTitle[0] == '0' + chno;
+                } else {
+                    return chapterNoFromTitle[0] == chno;
+                }
+            });
+            if (typeof chapterNo[0] === 'undefined') {
+                Materialize.toast(`Chapter ${chno} is not available
+                    for ${nmanga}`, 5000);
+                return;
+            }
 
             // Handling the chapter no input greater than number of chaps.
             if (chapterNo > chapters.length || chapterNo < 0) {
                 chapter = chapters[0];
             } else {
-                chapter = chapters[chapterNo];
+                chapter = chapterNo[0]; // bc chapterNo is also an array.
             }
-            // Creating the chapter name with actual ch number + title if exists.
-            let path = './imgs/' + nmanga + '/' + chapter.n + '/';
+
+            // Generating chapter no from its title. Since some of the mangas
+            // do not have number in api.
+            let chapterNoForPath = chapter.t.match(/\d+(\.\d+)?/);
+
+            // Creating the chapter name with actual ch number
+            let path = './imgs/' + nmanga + '/' + chapterNoForPath[0] + '/';
 
             mkdirp(path)
                 .catch(console.error);
 
             hakuneko.kissmanga.getPages(chapter, function(error, pages) {
                 if (!error) {
-                    let ctr = 1;
                     chapter.p = pages; // Will be usefull later.
-
+                    console.log(pages);
+                    console.log(pages.length);
                     pages.forEach(function(item) {
                         item = item.trim();
-                        let regex = new RegExp(/(.*\.jpe?g|.*\.png)/)
-                        item = item.match(regex);
+                        item = item.match(/(.*\.jpe?g|.*\.png)/);
 
                         // Downloading from Https, doesnt work
                         // So i had to convert it to http
@@ -47,21 +67,23 @@ function buttoKun() {
                         let newLink = "http://" + link[1];
 
                         console.log(newLink.match(/\d*.png|\d*.jpe?g/));
-                        let file = fs.createWriteStream(path +
-                            newLink.match(/\d*.png|\d*.jpe?g/));
+                        let file = fs.createWriteStream(path + "000" +
+                            newLink.match(/\d+\w\d*.png|\d+\w\d*.jpe?g/));
 
-                        ctr = ctr + 1;
                         let req = http.get(newLink, function(response) {
                             response.pipe(file)
                         });
                     });
-                    Materialize.toast('Downloading completed successfully!', 5000);
+                    Materialize.toast('Downloading completed' +
+                        'successfully!', 5000);
                 } else {
+
                     console.log(error);
                 }
             });
         } else {
             console.log(error);
+            Materialize.toast(`${nmanga} is not found in Kissmanga`, 5000);
         }
     });
 }

--- a/src/lib/mangasrc/kissmanga.js
+++ b/src/lib/mangasrc/kissmanga.js
@@ -26,7 +26,7 @@ function buttoKun() {
                 chapter = chapters[chapterNo];
             }
             // Creating the chapter name with actual ch number + title if exists.
-            let path = './imgs/' + nmanga + '/' + chapter.t + '/';
+            let path = './imgs/' + nmanga + '/' + chapter.n + '/';
 
             mkdirp(path)
                 .catch(console.error);

--- a/src/lib/mangasrc/lhscans.js
+++ b/src/lib/mangasrc/lhscans.js
@@ -23,24 +23,26 @@ function lhs() {
 
     fetch(url, { redirect: "manual" }).then(function(response) {
         if (response.status === 0) {
-            if (response.status === 0) {
-                console.log("Another Redirect Spoted!");
-
-                let pages = GetAvailableChapters(url, foldername, function(error, pages) {
-                    // finding chapter no.
-                    let reg = new RegExp(/(.*)(:?-)(.*)(:?.html)/);
-                    let newChNo = pages[0].match(reg);
-
-                    // Generating new path for last chapter!
-                    mpath = './imgs/' + foldername + '/' + newChNo[3] + '/'
-                    url = 'http://lhscans.com/' + pages[0];
+            url = 'http://lhscans.com/read-' +
+                foldername + '-raw-chapter-' + chno + '.html';
+            
+            fetch(url, { redirect: "manual" }).then(function(response) {
+                if(response.status === 0){
+                    let pages = GetAvailableChapters(url, foldername, function(error, pages) {
+                        // finding chapter no.
+                        let reg = new RegExp(/(.*)(:?-)(.*)(:?.html)/);
+                        let newChNo = pages[0].match(reg);
+                        console.log(newChNo);
+                        // Generating new path for last chapter!
+                        mpath = './imgs/' + foldername + '/' + newChNo[3] + '/'
+                        url = 'http://lhscans.com/' + pages[0];
+                        GetChapters(url, mpath);
+                    });
+                }else{
                     GetChapters(url, mpath);
-                });
-            } else {
-                url = 'http://lhscans.com/read-' +
-                    foldername + '-raw-chapter-' + chno + '.html';
-                GetChapters(url, mpath);
-            }
+                }
+            });
+
         } else {
             // Link is correct!
             GetChapters(url, mpath);
@@ -109,7 +111,7 @@ function GetAvailableChapters(url, foldername, callback) {
     mangaPage = mangaPage[1] + '.html';
     mangaPage = mangaPage.replace("read", "manga");
 
-    fetch(url, { redirect: "manual" }).then(function(response) {
+    fetch(mangaPage, { redirect: "manual" }).then(function(response) {
         if (response.status === 0) {
             // That means manga is not found
             Materialize.toast(`'${foldername}' is not available!`, 5000);

--- a/src/lib/mangasrc/lhscans.js
+++ b/src/lib/mangasrc/lhscans.js
@@ -14,18 +14,14 @@ function lhs() {
     let foldername = document.getElementById('fname').value;
     let chno = document.getElementById('chno').value;
 
-    let mpath = './imgs/' + foldername + '/' + chno + '/';
     foldername = foldername.toLowerCase()
     foldername = foldername.replace(/ /g, "-");
+    let mpath = './imgs/' + foldername + '/' + chno + '/';
 
     let url = 'http://lhscans.com/read-' +
         foldername + '-chapter-' + chno + '.html';
 
     fetch(url, { redirect: "manual" }).then(function(response) {
-        // Means there is a redirect on website.
-        // FIXME: If there's no chapter, website still redirects
-        // and because of below if clause, it downloads random chapter
-        // somehow!
         if (response.status === 0) {
             if (response.status === 0) {
                 console.log("Another Redirect Spoted!");
@@ -76,7 +72,6 @@ function GetChapters(url, mpath) {
 }
 
 function lhsDownloader(url, path) {
-
     request(url, function(err, resp, body) {
         if (!err && resp.statusCode == 200) {
             // First we get the image urls from lhscans.
@@ -107,9 +102,7 @@ function lhsDownloader(url, path) {
 
 // EDIT: Find a way to implement this into download!
 function GetAvailableChapters(url, callback) {
-
     let chapterList = []
-    // NOTE: need to parse the url 'till -chapter-...
     let regex = new RegExp(/(.*)(?:-chapter)/);
     // mangaPage returns to the given manga's manga page.
     let mangaPage = url.match(regex);
@@ -132,8 +125,6 @@ function GetAvailableChapters(url, callback) {
                             chapterList.push(info);
                         }
                     });
-                    // Find a way to return this value
-                    // Possible solutions -> callback, Promise
                     url = chapterList; // We can pass all of the array
                     callback && callback(null, url);
                 }
@@ -143,6 +134,6 @@ function GetAvailableChapters(url, callback) {
 }
 
 
-module.exports = {
-    lhs: lhs
-}
+// module.exports = {
+//     lhs: lhs
+// }

--- a/src/lib/mangasrc/lhscans.js
+++ b/src/lib/mangasrc/lhscans.js
@@ -116,21 +116,28 @@ function GetAvailableChapters(url, callback) {
     mangaPage = mangaPage[1] + '.html';
     mangaPage = mangaPage.replace("read", "manga");
 
-    // Need to find latest chapter!
-    request(mangaPage, function(error, response, body) {
-        if (!error && response.statusCode == 200) {
-            // First we get the image urls from lhscans.
-            const $ = cheerio.load(body);
-            $(body).find('a.chapter').each(function(index, element) {
-                let info = ($(element).attr('href'));
-                if (info) {
-                    chapterList.push(info);
+    fetch(url, { redirect: "manual" }).then(function(response) {
+        if (response.status === 0) {
+            // That means manga is not found
+            Materialize.toast('Manga is not available!', 5000);
+        } else {
+            // Need to find latest chapter!
+            request(mangaPage, function(error, response, body) {
+                if (!error && response.statusCode == 200) {
+                    // First we get the image urls from lhscans.
+                    const $ = cheerio.load(body);
+                    $(body).find('a.chapter').each(function(index, element) {
+                        let info = ($(element).attr('href'));
+                        if (info) {
+                            chapterList.push(info);
+                        }
+                    });
+                    // Find a way to return this value
+                    // Possible solutions -> callback, Promise
+                    url = chapterList; // We can pass all of the array
+                    callback && callback(null, url);
                 }
             });
-            // Find a way to return this value
-            // Possible solutions -> callback, Promise
-            url = chapterList; // We can pass all of the array
-            callback && callback(null, url);
         }
     });
 }

--- a/src/lib/mangasrc/lhscans.js
+++ b/src/lib/mangasrc/lhscans.js
@@ -26,7 +26,7 @@ function lhs() {
             if (response.status === 0) {
                 console.log("Another Redirect Spoted!");
 
-                let pages = GetAvailableChapters(url, function(error, pages) {
+                let pages = GetAvailableChapters(url, foldername, function(error, pages) {
                     // finding chapter no.
                     let reg = new RegExp(/(.*)(:?-)(.*)(:?.html)/);
                     let newChNo = pages[0].match(reg);
@@ -88,7 +88,7 @@ function lhsDownloader(url, path) {
                 // Creating file name for the image.
                 let file = fs.createWriteStream(path +
                     imgUrl.split('/').pop(-1).toLowerCase());
-                let req = http.get(imgUrl, function(response) {
+                let downloader = http.get(imgUrl, function(response) {
                     response.pipe(file)
                 });
             });
@@ -100,8 +100,8 @@ function lhsDownloader(url, path) {
     });
 }
 
-// EDIT: Find a way to implement this into download!
-function GetAvailableChapters(url, callback) {
+
+function GetAvailableChapters(url, foldername, callback) {
     let chapterList = []
     let regex = new RegExp(/(.*)(?:-chapter)/);
     // mangaPage returns to the given manga's manga page.
@@ -112,7 +112,7 @@ function GetAvailableChapters(url, callback) {
     fetch(url, { redirect: "manual" }).then(function(response) {
         if (response.status === 0) {
             // That means manga is not found
-            Materialize.toast('Manga is not available!', 5000);
+            Materialize.toast(`'${foldername}' is not available!`, 5000);
         } else {
             // Need to find latest chapter!
             request(mangaPage, function(error, response, body) {
@@ -132,8 +132,3 @@ function GetAvailableChapters(url, callback) {
         }
     });
 }
-
-
-// module.exports = {
-//     lhs: lhs
-// }


### PR DESCRIPTION
**Changes**:
- Fixed bugs:
  + #21 #14  
- Added bugs:
  + #24 
---
- Lhscans now takes the manga name and checks if its exists in their website. If not, prints an error msg `mangaName not found`. [lhscans.js line 112].
- Lhscans' validator was downloading the chapters 2 times.
- Kissmanga, the problem of the chapter numbers -> `001.001` is solved. Lots of regex used for geting the name of the chapter. Since the kissmanga module `hakuneko` does not have all of the chapter numbers in chapter.n, I had to parse title to get chapter number.
  + Also ordering chapters in array was causing missplacement #14. Now it's fixed and User can type which chapter they wants. ` . xxx's are also valid`
- Also new bug has popped up #24 . We cannot switch between resources after doing downloading. It occurs in kissmanga operations.
- Lastly, the viewer problem solved temporarily. The instructions given by @sasalx [main,js , viewer.html] 

---
![](https://www.madman.com.au/news/wp-content/uploads/assass.png)


